### PR TITLE
Use warning is error

### DIFF
--- a/nosetest.cfg
+++ b/nosetest.cfg
@@ -1,2 +1,0 @@
-[nosetests]
-detailed-errors = 1

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -32,6 +32,7 @@ class SpellingBuilder(Builder):
     def init(self):
         self.docnames = []
         self.document_data = []
+        self.misspelling_count = 0
 
         # Initialize the per-document filters
         if not hasattr(self.env, 'spelling_document_filters'):
@@ -136,10 +137,7 @@ class SpellingBuilder(Builder):
                         lineno, word,
                         self.format_suggestions(suggestions),
                     ))
-
-                    # We found at least one bad spelling, so set the status
-                    # code for the app to a value that indicates an error.
-                    self.app.statuscode = 1
+                    self.misspelling_count += 1
 
         self.checker.pop_filters()
         return
@@ -148,4 +146,6 @@ class SpellingBuilder(Builder):
         self.output.close()
         self.info('Spelling checker messages written to %s' %
                   self.output_filename)
+        if self.misspelling_count:
+            self.warning('Found %d misspelled words' % self.misspelling_count)
         return


### PR DESCRIPTION
There's value in not always failing on a spelling - for example, if you want to use the tool merely as a guideline rather than a strict check. We could add a spelling-specific option to make failures optional, but we already have a similar option available - Sphinx's `warning-is-error` option. Stop setting the builder status and instead emit a warning on build failures.
    
