### PR TITLE
Note that PyEnchant is unmaintained and fix links

### DIFF
--- a/README
+++ b/README
@@ -6,7 +6,7 @@
 
 This package contains sphinxcontrb.spelling, a spelling checker for
 Sphinx-based documentation.  It uses PyEnchant_ to produce a report
-showing misspelled words.
+showing misspelled words.  Note: PyEnchant is now unmaintained.
 
 Refer to the `main documentation page
 <http://www.doughellmann.com/docs/sphinxcontrib.spelling/>`__ for
@@ -33,4 +33,4 @@ USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
 OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
-.. _PyEnchant: http://www.rfk.id.au/software/pyenchant/
+.. _PyEnchant: https://github.com/rfk/pyenchant

--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -26,7 +26,7 @@ Input Options
 ``spelling_word_list_filename=['spelling_wordlist.txt','another_list.txt']``
   Same as above, but with several files of correctly spelled words.
 
-.. _PyEnchant tutorial: http://packages.python.org/pyenchant/tutorial.html
+.. _PyEnchant tutorial: https://github.com/rfk/pyenchant/blob/master/website/content/tutorial.rst
 
 Output Options
 ==============
@@ -90,7 +90,7 @@ to the list of known words for just that document.
      Goodger
 
 
-.. _PyEnchant: http://www.rfk.id.au/software/pyenchant/
+.. _PyEnchant: https://github.com/rfk/pyenchant
 
 Custom Word Filters
 ===================

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,6 +37,6 @@ Details
    history
 
 
-.. _PyEnchant: http://www.rfk.id.au/software/pyenchant/
+.. _PyEnchant: https://github.com/rfk/pyenchant
 
 .. _Sphinx: http://sphinx.pocoo.org/

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -10,11 +10,7 @@
 Installing sphinxcontrib.spelling
 =================================
 
-1. Follow the instructions on the PyEnchant_ site to install
-   **enchant** and then **PyEnchant**.
-2. Install the extension with pip: ``pip install sphinxcontrib-spelling``
-
-.. _PyEnchant: http://packages.python.org/pyenchant/
+Install the extension with pip: ``pip install sphinxcontrib-spelling``
 
 Configuration
 =============


### PR DESCRIPTION
PyEnchant is looking for a new maintainer a website no longer exists at
the old address.

Looks like external installation instructions are no longer needed.