### PR TITLE
Allow custom empty files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ env/
 TAGS
 *~
 .DS_Store
+.idea
+.vscode
 spelling/spelling_wordlist.txt
 .tox/
 .coverage/

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -113,7 +113,7 @@ class SpellingBuilder(Builder):
                 outfile.writelines(infile_contents)
 
                 # Check for newline, and add one if not present
-                if not infile_contents[-1].endswith('\n'):
+                if infile and not infile_contents[-1].endswith('\n'):
                     outfile.write(u'\n')
 
         return combined_word_list


### PR DESCRIPTION
Hello,
this might be a silly PR (and pretty small one) but I have encountered an issue when working on a PR to pandas.

Basically, I have a script that updates a custom wordlist with contributors names, but if the file is empty and I run the spelling check, then an exception is thrown `IndexError` since the check on line 116 assumes that the file is not empty.

Of course, there is a work around this, but perhaps this could be useful to people that would like to have an empty file and then update it in the future.