### PR TITLE
Get pyenchant from github

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-PyEnchant>=1.6.5
+git+https://github.com/raphaelm/pyenchant.git@patch-1#egg=pyenchant
 Sphinx>=0.6
 six


### PR DESCRIPTION
Since pyenchant is unmaintained, it does not detect libenchant-2. This simple patch fixed that for me.