### PR TITLE
Logging: use `warning()` instead of its deprecated alias

### DIFF
--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -189,5 +189,6 @@ class SpellingBuilder(Builder):
         logger.info('Spelling checker messages written to %s' %
                     self.output_filename)
         if self.misspelling_count:
-            logger.warn('Found %d misspelled words' % self.misspelling_count)
+            logger.warning('Found %d misspelled words' %
+                           self.misspelling_count)
         return


### PR DESCRIPTION
The `warning()`s alias `warn()` was never intended to be public, and
is deprecated since forever. See https://bugs.python.org/issue13235

Changed line is already covered by tests in `test_builder`.