### PR TITLE
No Python 2.7 support anymore.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifier =
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Topic :: Documentation

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,6 @@
 #!/usr/bin/env python
 import setuptools
 
-# In python < 2.7.4, a lazy loading of package `pbr` will break
-# setuptools if some other modules registered functions in `atexit`.
-# solution from: http://bugs.python.org/issue15881#msg170215
-try:
-    import multiprocessing  # flake8: noqa
-except ImportError:
-    pass
-
 setuptools.setup(
     setup_requires=['pbr'],
     pbr=True)


### PR DESCRIPTION
Since sphinx >= 2 dropped Python 2.7 support, this package also does.
Remove Trove 2.7 classifier and 2.7 bug workaround.