### PR TITLE
allow customizing with classes using import strings

### DIFF
--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -64,10 +64,11 @@ returned by the tokenizer to be checked.
   Boolean controlling whether words that are names of modules found on
   ``sys.path`` are treated as spelled properly. Defaults to ``True``.
 ``spelling_filters=[]``
-  List of filter classes to be added to the tokenizer that produces
-  words to be checked. The classes should be derived from
-  ``enchant.tokenize.Filter``. Refer to the `PyEnchant tutorial`_
-  for examples.
+  List of importable filter classes to be added to the tokenizer that
+  produces words to be checked. For example,
+  ``["enchant.tokenize.MentionFilter"]``.  The classes should be
+  derived from ``enchant.tokenize.Filter``. Refer to the `PyEnchant
+  tutorial`_ for examples.
 
 Private Dictionaries
 ====================


### PR DESCRIPTION
Allow the spelling_filters config option to contain strings that refer
to the classes instead of using the classes directly. This avoids
invalidating the config hash every time the config module is loaded,
which speeds up subsequent documentation builds because every file is
not processed every time.

Addresses #39