### PR TITLE
Add an option to show the line containing a misspelling for context

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,7 +38,6 @@ spelling_word_list_filename = [
 ]
 
 spelling_show_suggestions = True
-spelling_show_whole_line = True
 spelling_ignore_pypi_package_names = True
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,6 +38,7 @@ spelling_word_list_filename = [
 ]
 
 spelling_show_suggestions = True
+spelling_show_whole_line = True
 spelling_ignore_pypi_package_names = True
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -36,6 +36,11 @@ Output Options
   Boolean controlling whether suggestions for misspelled words are
   printed.  Defaults to False.
 
+``spelling_show_whole_line=False``
+  Boolean controlling whether the contents of the line containing each
+  misspelled word is printed, for more context about the location of each
+  word.  Defaults to False.
+
 Word Filters
 ============
 

--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -36,10 +36,10 @@ Output Options
   Boolean controlling whether suggestions for misspelled words are
   printed.  Defaults to False.
 
-``spelling_show_whole_line=False``
+``spelling_show_whole_line=True``
   Boolean controlling whether the contents of the line containing each
   misspelled word is printed, for more context about the location of each
-  word.  Defaults to False.
+  word.  Defaults to True.
 
 Word Filters
 ============

--- a/sphinxcontrib/spelling/__init__.py
+++ b/sphinxcontrib/spelling/__init__.py
@@ -20,7 +20,7 @@ def setup(app):
     # Report guesses about correct spelling
     app.add_config_value('spelling_show_suggestions', False, 'env')
     # Report the whole line that has the error
-    app.add_config_value('spelling_show_whole_line', False, 'env')
+    app.add_config_value('spelling_show_whole_line', True, 'env')
     # Set the language for the text
     app.add_config_value('spelling_lang', 'en_US', 'env')
     # Set the language for the tokenizer

--- a/sphinxcontrib/spelling/__init__.py
+++ b/sphinxcontrib/spelling/__init__.py
@@ -19,6 +19,8 @@ def setup(app):
     app.add_directive('spelling', SpellingDirective)
     # Report guesses about correct spelling
     app.add_config_value('spelling_show_suggestions', False, 'env')
+    # Report the whole line that has the error
+    app.add_config_value('spelling_show_whole_line', False, 'env')
     # Set the language for the text
     app.add_config_value('spelling_lang', 'en_US', 'env')
     # Set the language for the tokenizer

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -76,6 +76,7 @@ class SpellingBuilder(Builder):
             suggest=self.config.spelling_show_suggestions,
             word_list_filename=word_list,
             filters=f,
+            context_line=self.config.spelling_show_whole_line,
         )
 
         self.output_filename = os.path.join(self.outdir, 'output.txt')
@@ -179,18 +180,21 @@ class SpellingBuilder(Builder):
                     lineno = parent.line
 
                 # Check the text of the node.
-                for word, suggestions in self.checker.check(node.astext()):
+                misspellings = self.checker.check(node.astext())
+                for word, suggestions, context_line in misspellings:
                     msg_parts = [docname + '.rst']
                     if lineno:
                         msg_parts.append(darkgreen(str(lineno)))
                     msg_parts.append(red(word))
                     msg_parts.append(self.format_suggestions(suggestions))
+                    msg_parts.append(context_line)
                     msg = ':'.join(msg_parts)
                     logger.info(msg)
-                    self.output.write(u"%s:%s: (%s) %s\n" % (
+                    self.output.write(u"%s:%s: (%s) %s %s\n" % (
                         self.env.doc2path(docname, None),
                         lineno, word,
                         self.format_suggestions(suggestions),
+                        context_line,
                     ))
                     self.misspelling_count += 1
 

--- a/sphinxcontrib/spelling/tests/test_checker.py
+++ b/sphinxcontrib/spelling/tests/test_checker.py
@@ -8,7 +8,7 @@
 import os
 import unittest
 
-from sphinxcontrib.spelling.checker import SpellingChecker
+from sphinxcontrib.spelling.checker import SpellingChecker, line_of_index
 
 
 class TestChecker(unittest.TestCase):
@@ -18,9 +18,10 @@ class TestChecker(unittest.TestCase):
                                   suggest=False,
                                   word_list_filename=None,
                                   )
-        for word, suggestions in checker.check('This txt is wrong'):
+        for word, suggestions, line in checker.check('This txt is wrong'):
             assert not suggestions, 'Suggesting'
             assert word == 'txt'
+            assert line == ""
         return
 
     def test_with_suggestions(self):
@@ -28,9 +29,10 @@ class TestChecker(unittest.TestCase):
                                   suggest=True,
                                   word_list_filename=None,
                                   )
-        for word, suggestions in checker.check('This txt is wrong'):
+        for word, suggestions, line in checker.check('This txt is wrong'):
             assert suggestions, 'Not suggesting'
             assert word == 'txt'
+            assert line == ""
         return
 
     def test_with_wordlist(self):
@@ -40,8 +42,22 @@ class TestChecker(unittest.TestCase):
             word_list_filename=os.path.join(os.path.dirname(__file__),
                                             'test_wordlist.txt')
         )
-        words = [w for w, s in checker.check('This txt is wrong')]
+        words = [w for w, s, l in checker.check('This txt is wrong')]
         assert not words, 'Did not use personal word list file'
+        return
+
+    def test_with_context_line(self):
+        checker = SpellingChecker(lang='en_US',
+                                  suggest=False,
+                                  word_list_filename=None,
+                                  context_line=True,
+                                  )
+
+        text = 'Line one\nThis txt is wrong\nLine two'
+        for word, suggestions, line in checker.check(text):
+            assert not suggestions, 'Suggesting'
+            assert word == 'txt'
+            assert line == "This txt is wrong"
         return
 
     # NOTE(dhellmann): Fails after updating to testrepository.
@@ -54,3 +70,30 @@ class TestChecker(unittest.TestCase):
     #     for word, suggestions in checker.check('Dieser Txt ist falsch'):
     #         assert word == 'Txt'
     #     return
+
+
+class TestLineOfIndex(unittest.TestCase):
+
+    def test_one_line(self):
+        text = "foo bar baz"
+        assert line_of_index(text, 0) == text
+        assert line_of_index(text, 5) == text
+        assert line_of_index(text, len(text)) == text
+
+    def test_multi_line(self):
+        text = "\nfoo\n\nbar baz\n"
+
+        assert line_of_index(text, 0) == ""
+
+        assert line_of_index(text, 1) == "foo"
+        assert line_of_index(text, 2) == "foo"
+        assert line_of_index(text, 3) == "foo"
+        assert line_of_index(text, 4) == "foo"
+
+        assert line_of_index(text, 5) == ""
+
+        assert line_of_index(text, 6) == "bar baz"
+        assert line_of_index(text, 12) == "bar baz"
+        assert line_of_index(text, 13) == "bar baz"
+
+        assert line_of_index(text, 14) == ""


### PR DESCRIPTION
This adds a boolean `spelling_show_whole_line` option that includes the whole
line (the substring from the previous \n to the next \n) in the output for each
misspelling. This makes it easier to understand and locate misspellings in large
products.

The output from the example in #43 is now:

```
index.rst:1:xyz::different text xyz other text                                                                                                                                                                  
index.rst:1:xyz::some words xyz more words
```

which is much easier to locate, despite the file name and line numbers not being perfect.

Fixes #43