### PR TITLE
Mark as unsafe for parallel builds

### DIFF
--- a/sphinxcontrib/spelling/__init__.py
+++ b/sphinxcontrib/spelling/__init__.py
@@ -43,4 +43,4 @@ def setup(app):
     app.add_config_value('spelling_ignore_importable_modules', True, 'env')
     # Add any user-defined filter classes
     app.add_config_value('spelling_filters', [], 'env')
-    return {"parallel_read_safe": True}
+    return {"parallel_read_safe": False}


### PR DESCRIPTION
This is for issue #34, so that parallel builds fail with the appropriate error message.