### PR TITLE
Ignore files 

### DIFF
--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -26,12 +26,14 @@ Input Options
   multiple files.
 ``spelling_word_list_filename=['spelling_wordlist.txt','another_list.txt']``
   Same as above, but with several files of correctly spelled words.
-``spelling_ignore_filenames=['ignored_file']``
-  List specifying a list of files that should not be checked for spelling.
-  The file extension (e.g. ``.rst``) should not be used when naming a file
-  to ignore.
+``spelling_ignore_filenames=['ignored_file.rst']``
+  A list of glob-style patterns that should be ignored when checking spelling.
+  They are matched against the source file names relative to the source
+  directory, using slashes as directory separators on all platforms. See Sphinx's
+  `exclude_patterns`_ option for more details on glob-style patterns.
 
 .. _PyEnchant tutorial: https://github.com/rfk/pyenchant/blob/master/website/content/tutorial.rst
+.. _exclude_patterns : https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-exclude_patterns
 
 Output Options
 ==============

--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -26,6 +26,10 @@ Input Options
   multiple files.
 ``spelling_word_list_filename=['spelling_wordlist.txt','another_list.txt']``
   Same as above, but with several files of correctly spelled words.
+``spelling_ignore_filename=['ignored_file']``
+  List specifying a list of files that should not be checked for spelling.
+  The file extension (e.g. ``.rst``) should not be used when naming a file
+  to ignore.
 
 .. _PyEnchant tutorial: https://github.com/rfk/pyenchant/blob/master/website/content/tutorial.rst
 

--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -26,7 +26,7 @@ Input Options
   multiple files.
 ``spelling_word_list_filename=['spelling_wordlist.txt','another_list.txt']``
   Same as above, but with several files of correctly spelled words.
-``spelling_ignore_filenames=['ignored_file.rst']``
+``spelling_exclude_patterns=['ignored_*']``
   A list of glob-style patterns that should be ignored when checking spelling.
   They are matched against the source file names relative to the source
   directory, using slashes as directory separators on all platforms. See Sphinx's

--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -26,7 +26,7 @@ Input Options
   multiple files.
 ``spelling_word_list_filename=['spelling_wordlist.txt','another_list.txt']``
   Same as above, but with several files of correctly spelled words.
-``spelling_ignore_filename=['ignored_file']``
+``spelling_ignore_filenames=['ignored_file']``
   List specifying a list of files that should not be checked for spelling.
   The file extension (e.g. ``.rst``) should not be used when naming a file
   to ignore.

--- a/sphinxcontrib/spelling/__init__.py
+++ b/sphinxcontrib/spelling/__init__.py
@@ -55,6 +55,10 @@ def setup(app):
     app.add_config_value('spelling_ignore_importable_modules', True, 'env')
     # Add any user-defined filter classes
     app.add_config_value('spelling_filters', [], 'env')
+    # Set a user-provided list of files to ignore
+    app.add_config_value('spelling_ignore_filename',
+                         [],
+                         'env')
     return {
         "parallel_read_safe": True,
         "parallel_write_safe": True,

--- a/sphinxcontrib/spelling/__init__.py
+++ b/sphinxcontrib/spelling/__init__.py
@@ -56,7 +56,7 @@ def setup(app):
     # Add any user-defined filter classes
     app.add_config_value('spelling_filters', [], 'env')
     # Set a user-provided list of files to ignore
-    app.add_config_value('spelling_ignore_filename',
+    app.add_config_value('spelling_ignore_filenames',
                          [],
                          'env')
     return {

--- a/sphinxcontrib/spelling/__init__.py
+++ b/sphinxcontrib/spelling/__init__.py
@@ -56,7 +56,7 @@ def setup(app):
     # Add any user-defined filter classes
     app.add_config_value('spelling_filters', [], 'env')
     # Set a user-provided list of files to ignore
-    app.add_config_value('spelling_ignore_filenames',
+    app.add_config_value('spelling_exclude_patterns',
                          [],
                          'env')
     return {

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -177,6 +177,8 @@ class SpellingBuilder(Builder):
 
     def _find_misspellings(self, docname, doctree):
 
+        if docname in self.config.spelling_ignore_filename:
+            return
         # Build the document-specific word filter based on any good
         # words listed in spelling directives. If we have no such
         # words, we want to push an empty list of filters so that we

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -178,7 +178,7 @@ class SpellingBuilder(Builder):
 
     def _find_misspellings(self, docname, doctree):
 
-        excluded = Matcher(self.config.spelling_ignore_filenames)
+        excluded = Matcher(self.config.spelling_exclude_patterns)
         if excluded(self.env.doc2path(docname, None)):
             return
         # Build the document-specific word filter based on any good

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -177,7 +177,7 @@ class SpellingBuilder(Builder):
 
     def _find_misspellings(self, docname, doctree):
 
-        if docname in self.config.spelling_ignore_filename:
+        if docname in self.config.spelling_ignore_filenames:
             return
         # Build the document-specific word filter based on any good
         # words listed in spelling directives. If we have no such

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -16,6 +16,7 @@ from sphinx.builders import Builder
 from sphinx.util import logging
 from sphinx.util.console import darkgreen, red
 from sphinx.util.osutil import ensuredir
+from sphinx.util.matching import Matcher
 
 try:
     from enchant.tokenize import EmailFilter, WikiWordFilter
@@ -177,7 +178,8 @@ class SpellingBuilder(Builder):
 
     def _find_misspellings(self, docname, doctree):
 
-        if docname in self.config.spelling_ignore_filenames:
+        excluded = Matcher(self.config.spelling_ignore_filenames)
+        if excluded(self.env.doc2path(docname, None)):
             return
         # Build the document-specific word filter based on any good
         # words listed in spelling directives. If we have no such

--- a/sphinxcontrib/spelling/tests/test_builder.py
+++ b/sphinxcontrib/spelling/tests/test_builder.py
@@ -139,7 +139,7 @@ def test_ignore_file(sphinx_project):
     srcdir, outdir = sphinx_project
     add_file(srcdir, 'conf.py', '''
     extensions = ['sphinxcontrib.spelling']
-    spelling_ignore_filenames=['con*']
+    spelling_exclude_patterns=['con*']
     ''')
 
     add_file(srcdir, 'contents.rst', '''

--- a/sphinxcontrib/spelling/tests/test_builder.py
+++ b/sphinxcontrib/spelling/tests/test_builder.py
@@ -134,11 +134,12 @@ def test_several_word_lists(sphinx_project):
     # But not this one
     assert '(tihs)' in output_text
 
+
 def test_ignore_file(sphinx_project):
     srcdir, outdir = sphinx_project
     add_file(srcdir, 'conf.py', '''
     extensions = ['sphinxcontrib.spelling']
-    spelling_ignore_filename=['contents.rst']
+    spelling_ignore_filename=['contents']
     ''')
 
     add_file(srcdir, 'contents.rst', '''

--- a/sphinxcontrib/spelling/tests/test_builder.py
+++ b/sphinxcontrib/spelling/tests/test_builder.py
@@ -148,5 +148,6 @@ def test_ignore_file(sphinx_project):
     ''')
 
     stdout, stderr, output_text = get_sphinx_output(srcdir, outdir, 'contents')
-    # This should be fine now
-    assert '(Speeling)' not in output_text
+    # The 'contents.spelling' output file should not have been
+    # created, because the file is ignored.
+    assert output_text is None

--- a/sphinxcontrib/spelling/tests/test_builder.py
+++ b/sphinxcontrib/spelling/tests/test_builder.py
@@ -139,7 +139,7 @@ def test_ignore_file(sphinx_project):
     srcdir, outdir = sphinx_project
     add_file(srcdir, 'conf.py', '''
     extensions = ['sphinxcontrib.spelling']
-    spelling_ignore_filename=['contents']
+    spelling_ignore_filenames=['contents']
     ''')
 
     add_file(srcdir, 'contents.rst', '''

--- a/sphinxcontrib/spelling/tests/test_builder.py
+++ b/sphinxcontrib/spelling/tests/test_builder.py
@@ -133,3 +133,19 @@ def test_several_word_lists(sphinx_project):
     assert '(txt)' not in output_text
     # But not this one
     assert '(tihs)' in output_text
+
+def test_ignore_file(sphinx_project):
+    srcdir, outdir = sphinx_project
+    add_file(srcdir, 'conf.py', '''
+    extensions = ['sphinxcontrib.spelling']
+    spelling_ignore_filename=['contents.rst']
+    ''')
+
+    add_file(srcdir, 'contents.rst', '''
+    Welcome to Speeling Checker documentation!
+    ==========================================
+    ''')
+
+    stdout, stderr, output_text = get_sphinx_output(srcdir, outdir, 'contents')
+    # This should be fine now
+    assert '(Speeling)' not in output_text

--- a/sphinxcontrib/spelling/tests/test_builder.py
+++ b/sphinxcontrib/spelling/tests/test_builder.py
@@ -139,7 +139,7 @@ def test_ignore_file(sphinx_project):
     srcdir, outdir = sphinx_project
     add_file(srcdir, 'conf.py', '''
     extensions = ['sphinxcontrib.spelling']
-    spelling_ignore_filenames=['contents']
+    spelling_ignore_filenames=['con*']
     ''')
 
     add_file(srcdir, 'contents.rst', '''


### PR DESCRIPTION
This PR addresses #3 by adding a configuration option to provide a list of files which should be ignored and not spell-checked. There is a test case which verifies functionality and documentation for the new option has been added.