### PR TITLE
Remove unused fixtures dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ namespace_packages =
 test =
     pytest
     pytest-cov
-    fixtures>=3.0.0
     coverage!=4.4,>=4.0
 linter =
     flake8==3.8.2


### PR DESCRIPTION
Hi,
It looks like this isn't used any more since you switched to pytest.