### PR TITLE
Pass 'filters' as a keyword argument to pyenchant get_tokenizer()

### DIFF
--- a/sphinxcontrib/spelling/checker.py
+++ b/sphinxcontrib/spelling/checker.py
@@ -31,7 +31,7 @@ class SpellingChecker(object):
         if filters is None:
             filters = []
         self.dictionary = enchant.DictWithPWL(lang, word_list_filename)
-        self.tokenizer = get_tokenizer(tokenizer_lang, filters)
+        self.tokenizer = get_tokenizer(tokenizer_lang, filters=filters)
         self.original_tokenizer = self.tokenizer
         self.suggest = suggest
         self.context_line = context_line


### PR DESCRIPTION
Fixes warnings during tests:

    .../spelling/sphinxcontrib/spelling/checker.py:34: DeprecationWarning: passing 'filters' as a non-keyword argument to get_tokenizer() is deprecated

Tracks upstream change:

https://github.com/pyenchant/pyenchant/commit/36930b55ac9881445a262a355af74c83ceef28e1