### PR TITLE
Replace deprecated imp module with importlib

### DIFF
--- a/sphinxcontrib/spelling/filters.py
+++ b/sphinxcontrib/spelling/filters.py
@@ -8,7 +8,7 @@
 # TODO - Words with multiple uppercase letters treated as classes and ignored
 
 import builtins
-import imp
+import importlib
 import subprocess
 import xmlrpc.client as xmlrpc_client
 
@@ -190,14 +190,15 @@ class ImportableModuleFilter(Filter):
         if word not in self.sought_modules:
             self.sought_modules.add(word)
             try:
-                imp.find_module(word)
-            except UnicodeEncodeError:
+                spec = importlib.util.find_spec(word)
+            except (AttributeError, ImportError):
+                # Raises ModuleNotFoundError (subclass of ImportError) instead
+                # of AttributeError in Python 3.7+.
                 return False
-            except ImportError:
+            if spec is None:
                 return False
-            else:
-                self.found_modules.add(word)
-                return True
+            self.found_modules.add(word)
+            return True
         return word in self.found_modules
 
 


### PR DESCRIPTION
Fixes warning when running the tests:

    spelling/sphinxcontrib/spelling/filters.py:11: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses

Per the docs, use importlib.util.find_spec() instead of
imp.find_module(). See:

https://docs.python.org/3/library/imp.html#imp.find_module

For details on importlib.util.find_spec(), see:

https://docs.python.org/3/library/importlib.html#importlib.util.find_spec