### PR TITLE
Add missing trove classifiers for Python-3-only support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,8 @@ classifier =
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7


### PR DESCRIPTION
The packages is Python 3 only (no Python 2) so document as such.

Include the classifier "Programming Language :: Python :: 3" for
automated tools.