### PR TITLE
Document the project as stable and ready for production use

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ summary = Sphinx spelling extension
 home-page = https://github.com/sphinx-contrib/spelling
 python_requires = >=3.5
 classifier =
-    Development Status :: 4 - Beta
+    Development Status :: 5 - Production/Stable
     Environment :: Console
     Environment :: Web Environment
     Intended Audience :: Developers


### PR DESCRIPTION
Some big name projects, such as Django, have been using
sphinxcontrib-spelling for a very long time, suggesting it has reached a
more mature status than "beta".