### PR TITLE
Run pyupgrade across the codebase

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # sphinxcontrib.spelling documentation build configuration file, created by
 # sphinx-quickstart on Sun Apr 17 15:33:23 2011.
 #
@@ -51,8 +49,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'sphinxcontrib.spelling'
-copyright = u'2011, Doug Hellmann'
+project = 'sphinxcontrib.spelling'
+copyright = '2011, Doug Hellmann'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -189,8 +187,8 @@ htmlhelp_basename = 'sphinxcontribspellingdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'sphinxcontribspelling.tex', u'sphinxcontrib.spelling Documentation',
-   u'Doug Hellmann', 'manual'),
+  ('index', 'sphinxcontribspelling.tex', 'sphinxcontrib.spelling Documentation',
+   'Doug Hellmann', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -222,6 +220,6 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'sphinxcontribspelling', u'sphinxcontrib.spelling Documentation',
-     [u'Doug Hellmann'], 1)
+    ('index', 'sphinxcontribspelling', 'sphinxcontrib.spelling Documentation',
+     ['Doug Hellmann'], 1)
 ]

--- a/sphinxcontrib/__init__.py
+++ b/sphinxcontrib/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     sphinxcontrib
     ~~~~~~~~~~~~~

--- a/sphinxcontrib/spelling/asset.py
+++ b/sphinxcontrib/spelling/asset.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Copyright (c) 2020 Doug Hellmann.  All rights reserved.
 #

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Copyright (c) 2010 Doug Hellmann.  All rights reserved.
 #
@@ -7,7 +6,6 @@
 
 import collections
 import importlib
-import io
 import os
 import tempfile
 
@@ -128,21 +126,19 @@ class SpellingBuilder(Builder):
 
         word_list = self.config.spelling_word_list_filename
 
-        with io.open(combined_word_list,
-                     'w',
-                     encoding='UTF-8') as outfile:
+        with open(combined_word_list, 'w', encoding='UTF-8') as outfile:
             for word_file in word_list:
                 # Paths are relative
                 long_word_file = os.path.join(self.srcdir, word_file)
                 logger.info('Adding contents of {} to custom word list'.format(
                     long_word_file))
-                with io.open(long_word_file, 'r', encoding='UTF-8') as infile:
+                with open(long_word_file, encoding='UTF-8') as infile:
                     infile_contents = infile.readlines()
                 outfile.writelines(infile_contents)
 
                 # Check for newline, and add one if not present
                 if infile and not infile_contents[-1].endswith('\n'):
-                    outfile.write(u'\n')
+                    outfile.write('\n')
 
         return combined_word_list
 
@@ -157,17 +153,17 @@ class SpellingBuilder(Builder):
 
     def format_suggestions(self, suggestions):
         if not self.config.spelling_show_suggestions or not suggestions:
-            return u''
-        return u'[' + u', '.join(u'"%s"' % s for s in suggestions) + u']'
+            return ''
+        return '[' + ', '.join('"%s"' % s for s in suggestions) + ']'
 
-    TEXT_NODES = set([
+    TEXT_NODES = {
         'block_quote',
         'paragraph',
         'list_item',
         'term',
         'definition_list_item',
         'title',
-    ])
+    }
 
     def write_doc(self, docname, doctree):
         lines = list(self._find_misspellings(docname, doctree))
@@ -176,7 +172,7 @@ class SpellingBuilder(Builder):
             output_filename = os.path.join(self.outdir, docname + '.spelling')
             logger.info('Writing %s', output_filename)
             ensuredir(os.path.dirname(output_filename))
-            with io.open(output_filename, 'w', encoding='UTF-8') as output:
+            with open(output_filename, 'w', encoding='UTF-8') as output:
                 output.writelines(lines)
 
     def _find_misspellings(self, docname, doctree):
@@ -225,7 +221,7 @@ class SpellingBuilder(Builder):
                     msg_parts.append(context_line)
                     msg = ':'.join(msg_parts)
                     logger.info(msg)
-                    yield u"%s:%s: (%s) %s %s\n" % (
+                    yield "%s:%s: (%s) %s %s\n" % (
                         self.env.doc2path(docname, None),
                         lineno, word,
                         self.format_suggestions(suggestions),

--- a/sphinxcontrib/spelling/checker.py
+++ b/sphinxcontrib/spelling/checker.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Copyright (c) 2010 Doug Hellmann.  All rights reserved.
 #
@@ -14,7 +13,7 @@ else:
     enchant_import_error = None
 
 
-class SpellingChecker(object):
+class SpellingChecker:
     """Checks the spelling of blocks of text.
 
     Uses options defined in the sphinx configuration file to control

--- a/sphinxcontrib/spelling/directive.py
+++ b/sphinxcontrib/spelling/directive.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Copyright (c) 2010 Doug Hellmann.  All rights reserved.
 #

--- a/sphinxcontrib/spelling/filters.py
+++ b/sphinxcontrib/spelling/filters.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Copyright (c) 2010 Doug Hellmann.  All rights reserved.
 #
@@ -151,7 +150,7 @@ class IgnoreWordsFilter(Filter):
         return word in self.word_set
 
 
-class IgnoreWordsFilterFactory(object):
+class IgnoreWordsFilterFactory:
 
     def __init__(self, words):
         self.words = words
@@ -230,4 +229,4 @@ class ContributorFilter(IgnoreWordsFilter):
             return set()
         output = p.stdout.decode('utf-8')
         tokenizer = get_tokenizer('en_US', filters=[])
-        return set(word for word, pos in tokenizer(output))
+        return {word for word, pos in tokenizer(output)}

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Copyright (c) 2010 Doug Hellmann.  All rights reserved.
 #

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Copyright (c) 2010 Doug Hellmann.  All rights reserved.
 #

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Copyright (c) 2010 Doug Hellmann.  All rights reserved.
 #
@@ -12,7 +11,7 @@ from sphinxcontrib.spelling import filters
 
 def test_builtin_unicode():
     f = filters.PythonBuiltinsFilter(None)
-    assert not f._skip(u'passé')
+    assert not f._skip('passé')
 
 
 def test_builtin_regular():
@@ -29,11 +28,11 @@ def test_acronym():
 
 
 def test_acronym_unicode():
-    text = u'a front-end for DBM-style databases'
+    text = 'a front-end for DBM-style databases'
     t = get_tokenizer('en_US', [])
     f = filters.AcronymFilter(t)
     words = [w[0] for w in f(text)]
-    assert u'DBM' not in words, 'Failed to filter out acronym'
+    assert 'DBM' not in words, 'Failed to filter out acronym'
 
 
 def test_contributors():


### PR DESCRIPTION
pyupgrade is a tool to automatically upgrade syntax for newer versions
of the Python language. For details, see:

https://github.com/asottile/pyupgrade

As the project is Python 3 only, this tools applies several
simplifications:

- No longer need to specify Python file encoding. Python files are read
  as utf-8 by default.

- No longer need to prefix Unicode strings with u. Python 3 strings are
  Unicode by default.

- No longer need to use io.open() as the builtin open() supports all
  features.

- Use set literals and set comprehension.

- No longer need to inherit from object as Python 3 removed the legacy
  old-style classes.