### PR TITLE
Remove support for end-of-life Python 3.5

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -6,6 +6,12 @@
 
    unmaintained
 
+*Next release*
+==============
+
+- Drop support for Python 3.5. This version `is not maintained anymore
+  <https://devguide.python.org/devcycle/#end-of-life-branches>`__.
+
 6.0.0
 =====
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ author = Doug Hellmann
 author-email = doug@doughellmann.com
 summary = Sphinx spelling extension
 home-page = https://github.com/sphinx-contrib/spelling
-python_requires = >=3.5
+python_requires = >=3.6
 classifier =
     Development Status :: 5 - Production/Stable
     Environment :: Console
@@ -17,7 +17,6 @@ classifier =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -80,7 +80,7 @@ class SpellingBuilder(Builder):
             os.mkdir(self.outdir)
 
         word_list = self.get_wordlist_filename()
-        logger.info('Looking for custom word list in {}'.format(word_list))
+        logger.info(f'Looking for custom word list in {word_list}')
 
         self.checker = checker.SpellingChecker(
             lang=self.config.spelling_lang,

--- a/sphinxcontrib/spelling/filters.py
+++ b/sphinxcontrib/spelling/filters.py
@@ -226,7 +226,7 @@ class ContributorFilter(IgnoreWordsFilter):
             p = subprocess.run(cmd, check=True, stdout=subprocess.PIPE)
         except subprocess.CalledProcessError as err:
             logger.warning('Called: {}'.format(' '.join(cmd)))
-            logger.warning('Failed to scan contributors: {}'.format(err))
+            logger.warning(f'Failed to scan contributors: {err}')
             return set()
         output = p.stdout.decode('utf-8')
         tokenizer = get_tokenizer('en_US', filters=[])


### PR DESCRIPTION
Python 3.5 has been end-of-life since 2020-09-30.

See https://devguide.python.org/devcycle/#end-of-life-branches for a
full list of end-of-life Pythons.

Removing support for end-of-life Python allows for better adoption of
new Python features (such as f-strings and type hinting) and reduces the
project's testing and maintenance resources.

Using pypinfo, we can see Python 3.5 made up only a small percentage of
real life usage over the last month:

    $ pypinfo -md -pc sphinxcontrib-spelling pyversion

    | python_version | percent | download_count |
    | -------------- | ------: | -------------: |
    | 3.7            |  39.60% |         37,528 |
    | 2.7            |  34.30% |         32,506 |
    | 3.8            |  14.14% |         13,396 |
    | 3.6            |  11.26% |         10,675 |
    | 3.5            |   0.43% |            403 |
    | 3.9            |   0.26% |            244 |
    | 3.4            |   0.02% |             16 |
    | Total          |         |         94,768 |