### PR TITLE
Simplify and improve tox configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,8 +39,6 @@ test =
     pytest
     pytest-cov
     coverage!=4.4,>=4.0
-linter =
-    flake8==3.8.2
 
 [entry_points]
 sphinx.builders =

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,8 @@ minversion = 3.2.0
 envlist=py38,linter,docs
 
 [testenv]
-usedevelop = True
-deps=
-    .[test]
+extras =
+    test
 commands=
     pytest -v \
       --cov=sphinxcontrib.spelling \
@@ -14,11 +13,12 @@ commands=
 [testenv:linter]
 basepython=python3.8
 deps=
-    .[linter]
+    flake8==3.8.2
 setenv =
     BUILD=linter
 commands =
     flake8 sphinxcontrib setup.py
+skip_install = true
 
 [testenv:pkglint]
 deps=
@@ -26,6 +26,7 @@ deps=
 commands=
     python setup.py sdist bdist_wheel
     twine check dist/*.tar.gz dist/*.whl
+skip_install = true
 
 [flake8]
 show-source = True
@@ -37,8 +38,6 @@ basepython=python3.7
 setenv =
     BUILD=docs
     ENABLE_SPELLING=1
-deps =
-    .[docs]
 commands =
     sphinx-build -W -j auto -b html -d docs/build/doctrees docs/source docs/build/html
     sphinx-build -W -j auto -b spelling -d docs/build/doctrees docs/source docs/build/spelling
@@ -48,7 +47,5 @@ basepython=python3.7
 setenv =
     BUILD=docs
     ENABLE_SPELLING=1
-deps =
-    .[docs]
 commands =
     sphinx-build -W -j auto -b spelling -d docs/build/doctrees docs/source docs/build/spelling


### PR DESCRIPTION
Remove `usedevelop = True`. It is better to test the installed package
than an in-place one. Testing against the installed version is more
robust, representative, and catches some packaging issues.

Replace `deps = .[test]` with tox's builtin `extras` configuration
option. For details on this features, see:
https://tox.readthedocs.io/en/latest/config.html#conf-extras.

Use `skip_install = true` for the linter environment. Installing
sphinxcontrib-spelling to a virtual environment is unnecessary for
flake8 purposes. This saves a small amount of time when running tox as
there are fewer operations to perform. For details on this features,
see: https://tox.readthedocs.io/en/latest/config.html#conf-skip_install.
As the package installation no longer occurs, using the extras won't
apply so the flake8 dependency has moved to the tox.ini file.

Remove `deps = .[docs]` as the "docs" extras does not exist. As the
package itself requires Sphinx, there is no need for another extras.