### PR TITLE
Introduce isort for automated formatting of Python imports

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,8 +8,8 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-
-import sys, os
+import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/docs/source/developers.rst
+++ b/docs/source/developers.rst
@@ -21,6 +21,16 @@ To run the tests, you need ``tox`` installed, then just run
 ``tox``. This should run the unit tests, the source code linter, and
 try to build the current documentation.
 
+Coding style
+============
+
+Python imports are formatted and sorted using `isort
+<https://pycqa.github.io/isort/>`__. To format all files, run:
+
+.. code-block:: console
+
+   $ tox -e style
+
 Building Documentation
 ======================
 

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -13,8 +13,8 @@ import docutils.nodes
 from sphinx.builders import Builder
 from sphinx.util import logging
 from sphinx.util.console import darkgreen, red
-from sphinx.util.osutil import ensuredir
 from sphinx.util.matching import Matcher
+from sphinx.util.osutil import ensuredir
 
 try:
     from enchant.tokenize import EmailFilter, WikiWordFilter
@@ -23,8 +23,7 @@ except ImportError as imp_exc:
 else:
     enchant_import_error = None
 
-from . import checker
-from . import filters
+from . import checker, filters
 
 logger = logging.getLogger(__name__)
 

--- a/sphinxcontrib/spelling/filters.py
+++ b/sphinxcontrib/spelling/filters.py
@@ -9,12 +9,10 @@
 import builtins
 import importlib
 import subprocess
-import xmlrpc.client as xmlrpc_client
+from xmlrpc import client as xmlrpc_client
 
 from enchant.tokenize import Filter, get_tokenizer, tokenize, unit_tokenize
-
 from sphinx.util import logging
-
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -3,14 +3,12 @@
 #
 """Tests for SpellingBuilder
 """
-
-import pytest
-
 import codecs
 import io
 import os
 import textwrap
 
+import pytest
 from sphinx.application import Sphinx
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,14 +10,23 @@ commands=
       --cov=sphinxcontrib.spelling \
       --cov-report term-missing
 
+[testenv:style]
+deps =
+    isort>=5.0.1
+commands =
+    isort .
+skip_install = true
+
 [testenv:linter]
 basepython=python3.8
 deps=
     flake8==3.8.2
+    isort>=5.0.1
 setenv =
     BUILD=linter
 commands =
     flake8 sphinxcontrib setup.py
+    isort --check --diff .
 skip_install = true
 
 [testenv:pkglint]


### PR DESCRIPTION
isort is a command line tool to automate formatting of Python imports.
It makes all imports formatted in a consistent way.

This simplifies the contributor process by removing the need to think
about parts of the project's preferred coding style.