### PR TITLE
Remove unnecessary UnicodeEncodeError (due to Python 3)

### DIFF
--- a/sphinxcontrib/spelling/filters.py
+++ b/sphinxcontrib/spelling/filters.py
@@ -171,10 +171,7 @@ class PythonBuiltinsFilter(Filter):
     """Ignore names of built-in Python symbols.
     """
     def _skip(self, word):
-        try:
-            return hasattr(builtins, word)
-        except UnicodeEncodeError:
-            return False
+        return hasattr(builtins, word)
 
 
 class ImportableModuleFilter(Filter):


### PR DESCRIPTION
For Python 3, all attributes are Unicode strings. There is no encoding
done which was necessary for Python 2 to handle byte strings.