### PR TITLE
Replace codecs.open() with Python 3 builtin open()

### DIFF
--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -38,7 +38,7 @@ def get_sphinx_output(srcdir, outdir, docname):
     app.build()
     path = os.path.join(outdir, docname + '.spelling')
     try:
-        with codecs.open(path, 'r') as f:
+        with open(path, 'r') as f:
             output_text = f.read()
     except FileNotFoundError:
         output_text = None


### PR DESCRIPTION
Since Python 3, the builtin open() supports all features provided by
codecs.open() (much like io.open()). Its use is no longer required.