### PR TITLE
Remove remaining references to reno release notes manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,3 @@ ChangeLog
 /.coverage
 /.testrepository/
 /cover/
-
-# Created by reno
-RELEASENOTES.rst
-releasenotes/notes/reno.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     - env: BUILD=pkglint
       python: 3.8
 
-# Pull all of the history so we can use reno
+# Pull all of the history to test ContributorFilter.
 git:
   depth: false
 

--- a/docs/source/developers.rst
+++ b/docs/source/developers.rst
@@ -51,14 +51,4 @@ changes using ``Fixes #NUM``, replacing ``NUM`` with the issue number.
 Release Notes
 =============
 
-Please use reno_ to add a release note for each pull request.
-
-.. code-block:: console
-
-   $ tox -e docs
-   $ .tox/docs/bin/reno new slug
-   # edit file created by reno
-
-Refer to the reno_ documentation for more details.
-
-.. _reno: https://docs.openstack.org/reno/latest/
+Please add a release note for each pull request to ``docs/history.rst``.


### PR DESCRIPTION
Use of reno was removed in ba98010ef25573e1aa3a64ac7f91e039ab38ba9d.