### PR TITLE
Handle `ValueError` raised by `importlib.util.find_spec`

### DIFF
--- a/sphinxcontrib/spelling/filters.py
+++ b/sphinxcontrib/spelling/filters.py
@@ -187,7 +187,7 @@ class ImportableModuleFilter(Filter):
             self.sought_modules.add(word)
             try:
                 spec = importlib.util.find_spec(word)
-            except (AttributeError, ImportError):
+            except (AttributeError, ImportError, ValueError):
                 # Raises ModuleNotFoundError (subclass of ImportError) instead
                 # of AttributeError in Python 3.7+.
                 return False


### PR DESCRIPTION
Reported issue: https://github.com/sphinx-contrib/spelling/issues/96

In 6.0.0, `importlib.util.find_spec` was introduced as a replacement to `imp.find_module`.
However, there is a scenario where it can raise `ValueError` (new behaviour to this codebase):
https://docs.python.org/3/library/importlib.html#importlib.util.find_spec

This PR attempts to handle this scenario.

P.S. I could not find related test to this logic. I'd be happy to write one (and will try now), but I think, I'd need some assistance here. Any pointers?


Best,
Rust