### PR TITLE
Include all supported Pythons in the tox test matrix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.2.0
-envlist=py{39,py},linter,docs
+envlist=py{36,37,38,39,py3},linter,docs
 
 [testenv]
 extras =


### PR DESCRIPTION
Make it easier to test all supported Pythons to help ensure changes
don't introduce incompatibilities.