### PR TITLE
Parametrize test_contributors

### DIFF
--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -36,9 +36,9 @@ def test_acronym_unicode():
     assert 'DBM' not in words, 'Failed to filter out acronym'
 
 
-def test_contributors():
-    f = filters.ContributorFilter(None)
-    names = [
+@pytest.mark.parametrize(
+    "name",
+    [
         "Alex",
         "Atlakson",
         "Avram",
@@ -67,8 +67,10 @@ def test_contributors():
         "Tobias",
         "Tricoli",
     ]
-    for name in names:
-        assert f._skip(name)
+)
+def test_contributors(name):
+    f = filters.ContributorFilter(None)
+    assert f._skip(name)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Using pytest.mark.parametrize() allows each test case to run
independently. In the event of a test failure, the other parameters will
still run as separate tests.