### PR TITLE
Update history.rst with 7.0.0 release

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -6,8 +6,8 @@
 
    unmaintained
 
-*Next release*
-==============
+7.0.0
+=====
 
 This major release drops support for Python 3.5. This version `is not
 maintained anymore


### PR DESCRIPTION
Was released on Oct 19, 2020.

https://pypi.org/project/sphinxcontrib-spelling/7.0.0/#history