### PR TITLE
Revert "Replace deprecated imp module with importlib"

### DIFF
--- a/sphinxcontrib/spelling/filters.py
+++ b/sphinxcontrib/spelling/filters.py
@@ -7,7 +7,7 @@
 # TODO - Words with multiple uppercase letters treated as classes and ignored
 
 import builtins
-import importlib
+import imp
 import subprocess
 from xmlrpc import client as xmlrpc_client
 
@@ -184,12 +184,8 @@ class ImportableModuleFilter(Filter):
         if word not in self.sought_modules:
             self.sought_modules.add(word)
             try:
-                spec = importlib.util.find_spec(word)
-            except (AttributeError, ImportError, ValueError):
-                # Raises ModuleNotFoundError (subclass of ImportError) instead
-                # of AttributeError in Python 3.7+.
-                return False
-            if spec is None:
+                imp.find_module(word)
+            except ImportError:
                 return False
             self.found_modules.add(word)
             return True

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -84,3 +84,11 @@ def test_contributors(name):
 def test_importable_module_skip(word, expected):
     f = filters.ImportableModuleFilter(None)
     assert f._skip(word) is expected
+
+
+def test_importable_module_with_side_effets(tmpdir):
+    with tmpdir.as_cwd():
+        path = tmpdir.join('setup.py')
+        path.write('raise SystemExit\n')
+        f = filters.ImportableModuleFilter(None)
+        assert f._skip('setup.cfg') is False


### PR DESCRIPTION
This reverts commit db8d0b3a14de97ac9ecc571f75c1bc2991455b07.

Using importlib.find_spec() is not safe at runtime as it can import
modules which will cause side effects within environments.

From the docs:
https://docs.python.org/3/library/importlib.html#importlib.util.find_spec

> If name is for a submodule (contains a dot), the parent module is
> automatically imported.

This has caused issues in some projects, including python-ldap which
includes the word "setup.cfg" causing its "setup.py" file to be imported
which eventually raises a SystemExit error. A test was written to catch
this case.

A deprecation warning is preferable over system level side effects.