### PR TITLE
Introduce mypy for static type checking

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,3 +52,19 @@ sphinx.builders =
 
 [aliases]
 release = egg_info -RDb ''
+
+[mypy]
+python_version = 3.6
+check_untyped_defs = true
+disallow_any_generics = true
+disallow_incomplete_defs = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+ignore_missing_imports = true
+no_implicit_optional = true
+no_implicit_reexport = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unused_configs = true
+warn_unused_ignores = true

--- a/sphinxcontrib/spelling/__init__.py
+++ b/sphinxcontrib/spelling/__init__.py
@@ -3,8 +3,11 @@ try:
     import importlib.metadata as importlib_metadata
 except ImportError:
     # For everyone else
-    import importlib_metadata
+    import importlib_metadata  # type: ignore
 
+from typing import Any, Dict
+
+from sphinx.application import Sphinx
 from sphinx.util import logging
 
 from .asset import SpellingCollector
@@ -14,8 +17,10 @@ from .directive import SpellingDirective
 logger = logging.getLogger(__name__)
 
 
-def setup(app):
-    version = importlib_metadata.version('sphinxcontrib-spelling')
+def setup(app: Sphinx) -> Dict[str, Any]:
+    version = importlib_metadata.version(  # type: ignore
+        'sphinxcontrib-spelling'
+    )
     logger.info('Initializing Spelling Checker %s', version)
     app.add_builder(SpellingBuilder)
     # Register the 'spelling' directive for setting parameters within

--- a/sphinxcontrib/spelling/asset.py
+++ b/sphinxcontrib/spelling/asset.py
@@ -5,7 +5,11 @@
 
 import collections
 import contextlib
+from typing import Set
 
+import docutils.nodes
+from sphinx.application import Sphinx
+from sphinx.environment import BuildEnvironment
 from sphinx.environment.collectors import EnvironmentCollector
 from sphinx.util import logging
 
@@ -14,11 +18,22 @@ logger = logging.getLogger(__name__)
 
 class SpellingCollector(EnvironmentCollector):
 
-    def clear_doc(self, app, env, docname) -> None:
+    def clear_doc(
+        self,
+        app: Sphinx,
+        env: BuildEnvironment,
+        docname: str
+    ) -> None:
         with contextlib.suppress(AttributeError, KeyError):
             del env.spelling_document_words[docname]
 
-    def merge_other(self, app, env, docnames, other):
+    def merge_other(
+        self,
+        app: Sphinx,
+        env: BuildEnvironment,
+        docnames: Set[str],
+        other: BuildEnvironment
+    ) -> None:
         try:
             other_words = other.spelling_document_words
         except AttributeError:
@@ -28,5 +43,9 @@ class SpellingCollector(EnvironmentCollector):
             env.spelling_document_words = collections.defaultdict(list)
         env.spelling_document_words.update(other_words)
 
-    def process_doc(self, app, doctree):
+    def process_doc(
+        self,
+        app: Sphinx,
+        doctree: docutils.nodes.document
+    ) -> None:
         pass

--- a/sphinxcontrib/spelling/checker.py
+++ b/sphinxcontrib/spelling/checker.py
@@ -3,12 +3,13 @@
 #
 """Spelling checker extension for Sphinx.
 """
+from typing import Iterator, List, Optional, Tuple
 
 try:
     import enchant
-    from enchant.tokenize import get_tokenizer
+    from enchant.tokenize import Filter, get_tokenizer
 except ImportError as imp_exc:
-    enchant_import_error = imp_exc
+    enchant_import_error: Optional[ImportError] = imp_exc
 else:
     enchant_import_error = None
 
@@ -20,8 +21,15 @@ class SpellingChecker:
     the checking and filtering behavior.
     """
 
-    def __init__(self, lang, suggest, word_list_filename,
-                 tokenizer_lang='en_US', filters=None, context_line=False):
+    def __init__(
+        self,
+        lang: str,
+        suggest: bool,
+        word_list_filename: Optional[str],
+        tokenizer_lang: str = 'en_US',
+        filters: Optional[List[str]] = None,
+        context_line: bool = False
+    ):
         if enchant_import_error is not None:
             raise RuntimeError(
                 'Cannot instantiate SpellingChecker '
@@ -35,7 +43,7 @@ class SpellingChecker:
         self.suggest = suggest
         self.context_line = context_line
 
-    def push_filters(self, new_filters):
+    def push_filters(self, new_filters: List[Filter]) -> None:
         """Add a filter to the tokenizer chain.
         """
         t = self.tokenizer
@@ -43,12 +51,12 @@ class SpellingChecker:
             t = f(t)
         self.tokenizer = t
 
-    def pop_filters(self):
+    def pop_filters(self) -> None:
         """Remove the filters pushed during the last call to push_filters().
         """
         self.tokenizer = self.original_tokenizer
 
-    def check(self, text):
+    def check(self, text: str) -> Iterator[Tuple[str, List[str], str]]:
         """Yields bad words and suggested alternate spellings.
         """
         for word, pos in self.tokenizer(text):
@@ -60,10 +68,9 @@ class SpellingChecker:
             line = line_of_index(text, pos) if self.context_line else ""
 
             yield word, suggestions, line
-        return
 
 
-def line_of_index(text, index):
+def line_of_index(text: str, index: int) -> str:
     try:
         line_start = text.rindex("\n", 0, index) + 1
     except ValueError:

--- a/sphinxcontrib/spelling/directive.py
+++ b/sphinxcontrib/spelling/directive.py
@@ -5,7 +5,9 @@
 """
 
 import collections
+from typing import List
 
+import docutils.nodes
 from docutils.parsers import rst
 from sphinx.util import logging
 
@@ -24,7 +26,7 @@ class SpellingDirective(rst.Directive):
 
     has_content = True
 
-    def run(self):
+    def run(self) -> List[docutils.nodes.Node]:
         env = self.state.document.settings.env
 
         # Initialize the per-document good words list

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.2.0
-envlist=py{36,37,38,39,py3},linter,docs
+envlist=py{36,37,38,39,py3},mypy,linter,docs
 
 [testenv]
 extras =
@@ -27,6 +27,13 @@ setenv =
 commands =
     flake8 sphinxcontrib setup.py
     isort --check --diff .
+skip_install = true
+
+[testenv:mypy]
+deps =
+    mypy
+commands=
+    mypy sphinxcontrib
 skip_install = true
 
 [testenv:pkglint]


### PR DESCRIPTION
Help ensure APIs are used correctly, especially when refactoring.

The Sphinx project has long used types in its code base.
sphinxcontrib-spelling can take advantage of this by checking all public
APIs are used with expected types.