### PR TITLE
update publish action based on python.org instructions

### DIFF
--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -4,11 +4,11 @@
 name: Upload Python Package
 
 on:
-  release:
-    types: [created]
+  - push
 
 jobs:
-  deploy:
+  build-n-publish:
+    name: Build and publish Python distributions to PyPI and TestPyPI
 
     runs-on: ubuntu-latest
 
@@ -21,11 +21,17 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+        pip install setuptools wheel twine pbr
+    - name: Build sdist and wheel
       run: |
         python setup.py sdist bdist_wheel
-        twine upload dist/*
+    - name: Publish distribution to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish distribution to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
See
https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/