### PR TITLE
do not run the build-n-publish job on forks of the repo

### DIFF
--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-n-publish:
     name: Build and publish Python distributions to PyPI and TestPyPI
+    if: ${{ github.repository_owner == 'sphinx-contrib' }}
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Don't run an action that is likely to fail on a fork of the repo.