### PR TITLE
add spelling_warning configuration option

### DIFF
--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -47,6 +47,11 @@ Output Options
   misspelled word is printed, for more context about the location of each
   word.  Defaults to True.
 
+``spelling_warning=False``
+
+  Boolean controlling whether a misspelling is emitted as a sphinx
+  warning or as an info message. Defaults to False.
+
 Word Filters
 ============
 

--- a/sphinxcontrib/spelling/__init__.py
+++ b/sphinxcontrib/spelling/__init__.py
@@ -28,6 +28,8 @@ def setup(app):
     app.add_config_value('spelling_show_suggestions', False, 'env')
     # Report the whole line that has the error
     app.add_config_value('spelling_show_whole_line', True, 'env')
+    # Emit misspelling as a sphinx warning instead of info message
+    app.add_config_value('spelling_warning', False, 'env')
     # Set the language for the text
     app.add_config_value('spelling_lang', 'en_US', 'env')
     # Set the language for the tokenizer

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -12,7 +12,7 @@ import tempfile
 import docutils.nodes
 from sphinx.builders import Builder
 from sphinx.util import logging
-from sphinx.util.console import darkgreen, red
+from sphinx.util.console import red
 from sphinx.util.matching import Matcher
 from sphinx.util.osutil import ensuredir
 

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -210,10 +210,11 @@ class SpellingBuilder(Builder):
                 # Check the text of the node.
                 misspellings = self.checker.check(node.astext())
                 for word, suggestions, context_line in misspellings:
-                    msg_parts = [red(word)]
-                    msg_parts.append(self.format_suggestions(suggestions))
+                    msg_parts = ['Spell check', red(word)]
+                    if self.format_suggestions(suggestions) != '':
+                        msg_parts.append(self.format_suggestions(suggestions))
                     msg_parts.append(context_line)
-                    msg = 'Spell check: ' + ':'.join(msg_parts)
+                    msg = ': '.join(msg_parts) + '.'
                     loc = (docname, lineno) if lineno else docname
                     if self.config.spelling_warning:
                         logger.warning(msg, location=loc)

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -210,14 +210,19 @@ class SpellingBuilder(Builder):
                 # Check the text of the node.
                 misspellings = self.checker.check(node.astext())
                 for word, suggestions, context_line in misspellings:
-                    msg_parts = [docname + '.rst']
-                    if lineno:
-                        msg_parts.append(darkgreen(str(lineno)))
-                    msg_parts.append(red(word))
+                    msg_parts = [red(word)]
                     msg_parts.append(self.format_suggestions(suggestions))
                     msg_parts.append(context_line)
-                    msg = ':'.join(msg_parts)
-                    logger.info(msg)
+                    if self.config.spelling_warning:
+                        loc = (docname, lineno) if lineno else docname
+                        msg = 'Spell check: ' + ':'.join(msg_parts)
+                        logger.warning(msg, location=loc)
+                    else:
+                        loc = [docname + '.rst']
+                        if lineno:
+                            loc.append(darkgreen(str(lineno)))
+                        msg = ':'.join(loc + msg_parts)
+                        logger.info(msg)
                     yield "%s:%s: (%s) %s %s\n" % (
                         self.env.doc2path(docname, None),
                         lineno, word,

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -213,16 +213,12 @@ class SpellingBuilder(Builder):
                     msg_parts = [red(word)]
                     msg_parts.append(self.format_suggestions(suggestions))
                     msg_parts.append(context_line)
+                    msg = 'Spell check: ' + ':'.join(msg_parts)
+                    loc = (docname, lineno) if lineno else docname
                     if self.config.spelling_warning:
-                        loc = (docname, lineno) if lineno else docname
-                        msg = 'Spell check: ' + ':'.join(msg_parts)
                         logger.warning(msg, location=loc)
                     else:
-                        loc = [docname + '.rst']
-                        if lineno:
-                            loc.append(darkgreen(str(lineno)))
-                        msg = ':'.join(loc + msg_parts)
-                        logger.info(msg)
+                        logger.info(msg, location=loc)
                     yield "%s:%s: (%s) %s %s\n" % (
                         self.env.doc2path(docname, None),
                         lineno, word,


### PR DESCRIPTION
Resolves #108 

Adds a config option:  spelling_warning that will emit misspellings as sphinx warning instead of info message. The sphinx warning format is better suited for IDE's that no how to parse error/warnings and automatically navigate to the file/line. Also, you can invoke sphinx with -q and still see warnings.