### PR TITLE
Correct setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,10 +2,9 @@
 name = sphinxcontrib-spelling
 description-file = README
 author = Doug Hellmann
-author-email = doug@doughellmann.com
+author_email = doug@doughellmann.com
 summary = Sphinx spelling extension
-home-page = https://github.com/sphinx-contrib/spelling
-python_requires = >=3.6
+home_page = https://github.com/sphinx-contrib/spelling
 classifier =
     Development Status :: 5 - Production/Stable
     Environment :: Console
@@ -25,6 +24,9 @@ classifier =
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Documentation
     Topic :: Utilities
+
+[options]
+python_requires = >=3.6
 
 [global]
 setup-hooks =


### PR DESCRIPTION
* Move `python_requires` to `[options]` section, where it belongs: https://setuptools.pypa.io/en/latest/userguide/declarative_config.html
* Use underscores for keys rather than dashes; dashes happen to work but are not documented: https://github.com/asottile/setup-cfg-fmt#normalizes-dashes-to-underscores-in-keys