### PR TITLE
Improve ImportableModuleFilter

### DIFF
--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -79,6 +79,7 @@ def test_contributors(name):
         ('os', True),
         ('os.name', False),
         ('__main__', False),
+        ("don't", False),
     ]
 )
 def test_importable_module_skip(word, expected):


### PR DESCRIPTION
* Add ``sys.builtin_module_names`` to the initial sets, to skip running ``imp.find_module`` for these names which we know will succeed.
* Check that the given name is a valid module name with a cheap string check, before trying to run the more expensive ``imp.find_module()``.
* Close the file returned by ``imp.find_module()`` to avoid this resource warning:

```
/.../site-packages/sphinxcontrib/spelling/filters.py:187: ResourceWarning: unclosed file <_io.TextIOWrapper name='/.../site-packages/decorator.py' mode='r' encoding='utf-8'>
  imp.find_module(word)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```