### PR TITLE
filters: do not use imp in ImportableModuleFilter

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.2.0
-envlist=py{36,37,38,39,310,py3},linter,docs
+envlist=py{37,38,39,310},linter,docs
 
 [testenv]
 extras =


### PR DESCRIPTION
The imp module is deprecated, so replace it with calls to importlib.

Addresses #124