### PR TITLE
history-update: do not run check if ref is a tag

### DIFF
--- a/.github/workflows/history-update.yaml
+++ b/.github/workflows/history-update.yaml
@@ -18,4 +18,5 @@ jobs:
           fetch-depth: 0
 
       - name: Check for history.rst update
+        if: startsWith(github.ref, 'refs/tags') != true
         run: ./tools/history-update.sh

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,8 +11,10 @@ pull_request_rules:
         - "check-success=build (3.8)"
         - "check-success=build (3.9)"
         - "check-success=build (3.10)"
-        - "check-success=history-update"
         - "-draft"
+        - or:
+          - "check-success=history-update"
+          - "label=ci"
         - or:
           - "approved-reviews-by=dhellmann"
           - "author=dhellmann"


### PR DESCRIPTION
There's no need to run the check if we push a tag reference.