### PR TITLE
filters: treat __main__ as special

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -6,6 +6,18 @@
 
    unmaintained
 
+7.3.2
+=====
+
+Bug Fixes
+---------
+
+- `#141 <https://github.com/sphinx-contrib/spelling/pull/141>`__ Treat
+  `__main__` as a special module name that cannot be imported. If the
+  test suite is invoked by running `python -m pytest` instead of
+  `pytest` then there will be no `__main__` and find_spec() will fail,
+  so this change makes the tests work in both modes.
+
 7.3.1
 =====
 

--- a/sphinxcontrib/spelling/filters.py
+++ b/sphinxcontrib/spelling/filters.py
@@ -180,6 +180,12 @@ class ImportableModuleFilter(Filter):
         super().__init__(tokenizer)
         self.found_modules = set(sys.builtin_module_names)
         self.sought_modules = self.found_modules.copy()
+        # By adding __main__ to the list of sought modules but not
+        # found modules we ensure that it is never recognized as a
+        # valid module, which is consistent with the behavior before
+        # version 7.3.1.  See
+        # https://github.com/sphinx-contrib/spelling/issues/141
+        self.sought_modules.add('__main__')
 
     def _skip(self, word):
         valid_module_name = all(n.isidentifier() for n in word.split('.'))


### PR DESCRIPTION
If the test suite is invoked by running `python -m pytest` instead of
`pytest` then there will be no `__main__` and find_spec() will fail.

Fixes #141