### PR TITLE
filters: fix python filename handling

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -12,11 +12,11 @@
 Bug Fixes
 ---------
 
-- `#141 <https://github.com/sphinx-contrib/spelling/pull/141>`__ Treat
-  `__main__` as a special module name that cannot be imported. If the
-  test suite is invoked by running `python -m pytest` instead of
-  `pytest` then there will be no `__main__` and find_spec() will fail,
-  so this change makes the tests work in both modes.
+- `#143 <https://github.com/sphinx-contrib/spelling/pull/143>`__ Treat
+  ``__main__`` as a special module name that cannot be imported. If
+  the test suite is invoked by running ``python -m pytest`` instead of
+  ``pytest`` then there will be no ``__main__`` and find_spec() will
+  fail, so this change makes the tests work in both modes.
 - `#144 <https://github.com/sphinx-contrib/spelling/pull/144>`__ Fix
   python filename handling in ``ImportableModuleFilter``.  If the word
   looks like a python module filename, strip the extension to avoid

--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -17,6 +17,13 @@ Bug Fixes
   test suite is invoked by running `python -m pytest` instead of
   `pytest` then there will be no `__main__` and find_spec() will fail,
   so this change makes the tests work in both modes.
+- `#144 <https://github.com/sphinx-contrib/spelling/pull/144>`__ Fix
+  python filename handling in ``ImportableModuleFilter``.  If the word
+  looks like a python module filename, strip the extension to avoid
+  the side-effect of actually importing the module. This prevents, for
+  example, ``'setup.py'`` triggering an import of the ``setup`` module
+  during a doc build, which makes it look like Sphinx is complaining
+  about a commandline argument.
 
 7.3.1
 =====

--- a/sphinxcontrib/spelling/filters.py
+++ b/sphinxcontrib/spelling/filters.py
@@ -188,6 +188,19 @@ class ImportableModuleFilter(Filter):
         self.sought_modules.add('__main__')
 
     def _skip(self, word):
+        # If the word looks like a python module filename, strip the
+        # extension to avoid the side-effect of actually importing the
+        # module. This prevents, for example, 'setup.py' triggering an
+        # import of the setup module during a doc build, which makes
+        # it look like Sphinx is complaining about a commandline
+        # argument. See
+        # https://github.com/sphinx-contrib/spelling/issues/142
+        if word.endswith('.py'):
+            logger.debug(
+                'removing .py extension from %r before searching for module',
+                word)
+            word = word[:-3]
+
         valid_module_name = all(n.isidentifier() for n in word.split('.'))
         if not valid_module_name:
             return False
@@ -207,6 +220,7 @@ class ImportableModuleFilter(Filter):
             else:
                 if mod is not None:
                     self.found_modules.add(word)
+
         return word in self.found_modules
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist=py{37,38,39,310},linter,docs
 extras =
     test
 commands=
-    pytest -v \
+    pytest \
       --cov=sphinxcontrib.spelling \
       --cov-report term-missing
 


### PR DESCRIPTION
If the word looks like a python module filename, strip the extension to
avoid the side-effect of actually importing the module. This prevents, for
example, 'setup.py' triggering an import of the setup module during a doc
build, which makes it look like Sphinx is complaining about a commandline
argument.

Fixes #142