### PR TITLE
handle empty word list

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -6,6 +6,14 @@
 
    unmaintained
 
+Next
+====
+
+- Fix a problem that occurred when the extra word list is empty and an
+  IndexError is thrown. Prevent the error by checking the contents of
+  the file before using the list.
+
+
 7.3.3
 =====
 

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -133,7 +133,7 @@ class SpellingBuilder(Builder):
                 outfile.writelines(infile_contents)
 
                 # Check for newline, and add one if not present
-                if infile and not infile_contents[-1].endswith('\n'):
+                if infile_contents and not infile_contents[-1].endswith('\n'):
                     outfile.write('\n')
 
         return combined_word_list


### PR DESCRIPTION
If the extra word list is empty an IndexError is thrown. Prevent the
error by checking the contents of the file before using the list.