### PR TITLE
Use the line of the misspelled word as source position in message

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -29,7 +29,9 @@ Next
   but we don't want to set it in this file for everyone so use
   `passenv` to tell tox to pass the setting through when running the
   commands for each env.
-
+- `#159 <https://github.com/sphinx-contrib/spelling/issues/159>`__
+  Report using the line number of the misspelled word instead of
+  using the first line of the node.
 
 7.3.3
 =====

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -204,9 +204,9 @@ class SpellingBuilder(Builder):
 
                 # Check the text of the node.
                 misspellings = self.checker.check(node.astext())
-                for word, suggestions, context_line, line_offs in misspellings:
+                for word, suggestions, context_line, line_offset in misspellings:
                     msg_parts = [
-                        f'{source}:{lineno+line_offs}: ',
+                        f'{source}:{lineno+line_offset}: ',
                         'Spell check',
                         red(word),
                     ]

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -204,7 +204,12 @@ class SpellingBuilder(Builder):
 
                 # Check the text of the node.
                 misspellings = self.checker.check(node.astext())
-                for word, suggestions, context_line, line_offset in misspellings:
+                for (
+                    word,
+                    suggestions,
+                    context_line,
+                    line_offset
+                ) in misspellings:
                     msg_parts = [
                         f'{source}:{lineno+line_offset}: ',
                         'Spell check',

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -204,9 +204,9 @@ class SpellingBuilder(Builder):
 
                 # Check the text of the node.
                 misspellings = self.checker.check(node.astext())
-                for word, suggestions, context_line in misspellings:
+                for word, suggestions, context_line, line_offs in misspellings:
                     msg_parts = [
-                        f'{source}:{lineno}: ',
+                        f'{source}:{lineno+line_offs}: ',
                         'Spell check',
                         red(word),
                     ]

--- a/sphinxcontrib/spelling/checker.py
+++ b/sphinxcontrib/spelling/checker.py
@@ -58,9 +58,9 @@ class SpellingChecker:
 
             suggestions = self.dictionary.suggest(word) if self.suggest else []
             line = line_of_index(text, pos) if self.context_line else ""
-            line_offs = text.count("\n", 0, pos)
+            line_offset = text.count("\n", 0, pos)
 
-            yield word, suggestions, line, line_offs
+            yield word, suggestions, line, line_offset
 
 
 def line_of_index(text, index):

--- a/sphinxcontrib/spelling/checker.py
+++ b/sphinxcontrib/spelling/checker.py
@@ -58,8 +58,9 @@ class SpellingChecker:
 
             suggestions = self.dictionary.suggest(word) if self.suggest else []
             line = line_of_index(text, pos) if self.context_line else ""
+            line_offs = text.count("\n", 0, pos)
 
-            yield word, suggestions, line
+            yield word, suggestions, line, line_offs
 
 
 def line_of_index(text, index):

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -14,10 +14,11 @@ def test_errors_only():
                               suggest=False,
                               word_list_filename=None,
                               )
-    for word, suggestions, line in checker.check('This txt is wrong'):
+    for word, suggestions, line, offset in checker.check('This txt is wrong'):
         assert not suggestions, 'Suggesting'
         assert word == 'txt'
         assert line == ""
+        assert offset == 0
 
 
 def test_with_suggestions():
@@ -25,11 +26,11 @@ def test_with_suggestions():
                               suggest=True,
                               word_list_filename=None,
                               )
-    for word, suggestions, line in checker.check('This txt is wrong'):
+    for word, suggestions, line, offset in checker.check('This txt is wrong'):
         assert suggestions, 'Not suggesting'
         assert word == 'txt'
         assert line == ""
-
+        assert offset == 0
 
 def test_with_wordlist():
     checker = SpellingChecker(
@@ -38,7 +39,7 @@ def test_with_wordlist():
         word_list_filename=os.path.join(os.path.dirname(__file__),
                                         'test_wordlist.txt')
     )
-    words = [w for w, s, l in checker.check('This txt is wrong')]
+    words = [w for w, s, l, o in checker.check('This txt is wrong')]
     assert not words, 'Did not use personal word list file'
 
 
@@ -50,10 +51,11 @@ def test_with_context_line():
                               )
 
     text = 'Line one\nThis txt is wrong\nLine two'
-    for word, suggestions, line in checker.check(text):
+    for word, suggestions, line, offset in checker.check(text):
         assert not suggestions, 'Suggesting'
         assert word == 'txt'
         assert line == "This txt is wrong"
+        assert offset == 1
 
 
 def test_line_of_index_one_line():


### PR DESCRIPTION
A fix to #159 