### PR TITLE
builder: include the line offset in location saved to output file

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -30,8 +30,9 @@ Next
   `passenv` to tell tox to pass the setting through when running the
   commands for each env.
 - `#159 <https://github.com/sphinx-contrib/spelling/issues/159>`__
-  Report using the line number of the misspelled word instead of
-  using the first line of the node.
+  Report using the line number of the misspelled word instead of using
+  the first line of the node, in both the log and `.spelling` output
+  file.
 
 7.3.3
 =====

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -224,7 +224,7 @@ class SpellingBuilder(Builder):
                     elif self.config.spelling_verbose:
                         logger.info(msg)
                     yield "%s:%s: (%s) %s %s\n" % (
-                        source, lineno, word,
+                        source, lineno + line_offset, word,
                         self.format_suggestions(suggestions),
                         context_line,
                     )


### PR DESCRIPTION
Previous commits included the offset in the log message, this updates
the data saved to the output .spelling file to include the same value.

Fixes #159 