### PR TITLE
Support list of wordlists as a string

### DIFF
--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -27,8 +27,10 @@ Input Options
   String specifying a file containing a list of words known to be
   spelled correctly but that do not appear in the language dictionary
   selected by ``spelling_lang``.  The file should contain one word per
-  line. Refer to the `PyEnchant tutorial`_ for details. Use a list to add
-  multiple files.
+  line. Refer to the `PyEnchant tutorial`_ for details. To add multiple
+  files use a list, or a comma separated string. This is useful when
+  calling sphinx with ``-D spelling_word_list_filename=...`` which will
+  not accept a list and will only accept a string parameter.
 
 ``spelling_word_list_filename=['spelling_wordlist.txt','another_list.txt']``
 
@@ -37,9 +39,7 @@ Input Options
 ``spelling_word_list_filename='spelling_wordlist.txt,another_list.txt'``
 
   Same as above, but with several files of correctly spelled words, and
-  passing the setting as a single string. This is useful when calling
-  sphinx with ``-D spelling_word_list_filename=...`` which will only
-  accept a string parameter.
+  passing the setting as a single string. 
 
 ``spelling_exclude_patterns=['ignored_*']``
 

--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -34,6 +34,13 @@ Input Options
 
   Same as above, but with several files of correctly spelled words.
 
+``spelling_word_list_filename='spelling_wordlist.txt,another_list.txt'``
+
+  Same as above, but with several files of correctly spelled words, and
+  passing the setting as a single string. This is useful when calling
+  sphinx with ``-D spelling_word_list_filename=...`` which will only
+  accept a string parameter.
+
 ``spelling_exclude_patterns=['ignored_*']``
 
   A list of glob-style patterns that should be ignored when checking spelling.

--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -12,7 +12,7 @@
 Unreleased
 ==========
 
-- `#161 <https://github.com/sphinx-contrib/spelling/issues/161>`__
+- `#169 <https://github.com/sphinx-contrib/spelling/issues/169>`__
   Adds the ability to pass in mulitple wordlists via the sphinx
   command line as ``-D spelling_word_list_filename=file1,file2``.
 

--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -9,6 +9,13 @@
    macOS
    unmaintained
 
+Unreleased
+==========
+
+- `#161 <https://github.com/sphinx-contrib/spelling/issues/161>`__
+  Adds the ability to pass in mulitple wordlists via the sphinx
+  command line as ``-D spelling_word_list_filename=file1,file2``.
+
 7.4.1
 =====
 

--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -13,7 +13,7 @@ Unreleased
 ==========
 
 - `#169 <https://github.com/sphinx-contrib/spelling/issues/169>`__
-  Adds the ability to pass in mulitple wordlists via the sphinx
+  Adds the ability to pass in multiple wordlists via the sphinx
   command line as ``-D spelling_word_list_filename=file1,file2``.
 
 7.4.1

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -106,12 +106,10 @@ class SpellingBuilder(Builder):
         if word_list is None:
             word_list = 'spelling_wordlist.txt'
 
-        if (isinstance(word_list, str) and 
-            word_list.startswith('[') and 
-            word_list.endswith(']')):
+        if isinstance(word_list, str) and word_list.find(',') > 0:
             # Wordlist is a list, formatted as a str.
             # Split it back into a list
-            word_list = word_list[1:-1].split(',')
+            word_list = word_list.split(',')
 
         if not isinstance(word_list, list):
             return os.path.join(self.srcdir, word_list)

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -106,6 +106,13 @@ class SpellingBuilder(Builder):
         if word_list is None:
             word_list = 'spelling_wordlist.txt'
 
+        if (isinstance(word_list, str) and 
+            word_list.startswith('[') and 
+            word_list.endswith(']')):
+            # Wordlist is a list, formatted as a str.
+            # Split it back into a list
+            word_list = word_list[1:-1].split(',')
+
         if not isinstance(word_list, list):
             return os.path.join(self.srcdir, word_list)
 


### PR DESCRIPTION
Allow the spelling_word_list_filename to be passed as a string, but still be a list filenames and treated as such

Fix for issue #169 