### PR TITLE
feature: limit the suggestions shown in the output

### DIFF
--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -52,7 +52,13 @@ Output Options
 ``spelling_show_suggestions=False``
 
   Boolean controlling whether suggestions for misspelled words are
-  printed.  Defaults to False.
+  printed.  Defaults to ``False``.
+
+``spelling_suggestion_limit=0``
+
+  Integer number of suggestions to emit when
+  ``spelling_show_suggestions`` is ``True``. Defaults to ``0``,
+  meaning no limit. Any positive value truncates the suggestion limit.
 
 ``spelling_show_whole_line=True``
 

--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -9,6 +9,17 @@
    macOS
    unmaintained
 
+Next
+====
+
+Features
+--------
+
+- `#151 <https://github.com/sphinx-contrib/spelling/issues/151>`__
+  Added configuration option to limit the number of suggestions
+  output. See :doc:`/customize` for more details. Idea contributed by
+  Trevor Gross.
+
 7.4.1
 =====
 

--- a/sphinxcontrib/spelling/__init__.py
+++ b/sphinxcontrib/spelling/__init__.py
@@ -26,6 +26,8 @@ def setup(app):
     app.add_env_collector(SpellingCollector)
     # Report guesses about correct spelling
     app.add_config_value('spelling_show_suggestions', False, 'env')
+    # Limit the number of suggestions output
+    app.add_config_value('spelling_suggestion_limit', 0, 'env')
     # Report the whole line that has the error
     app.add_config_value('spelling_show_whole_line', True, 'env')
     # Emit misspelling as a sphinx warning instead of info message

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -148,10 +148,23 @@ class SpellingBuilder(Builder):
     def get_target_uri(self, docname, typ=None):
         return ''
 
-    def format_suggestions(self, suggestions):
+    def get_suggestions_to_show(self, suggestions):
         if not self.config.spelling_show_suggestions or not suggestions:
+            return []
+        to_show = suggestions
+        try:
+            n_to_show = int(self.config.spelling_suggestion_limit)
+        except ValueError:
+            n_to_show = 0
+        if n_to_show > 0:
+            to_show = suggestions[:n_to_show]
+        return to_show
+
+    def format_suggestions(self, suggestions):
+        to_show = self.get_suggestions_to_show(suggestions)
+        if not to_show:
             return ''
-        return '[' + ', '.join('"%s"' % s for s in suggestions) + ']'
+        return '[' + ', '.join('"%s"' % s for s in to_show) + ']'
 
     TEXT_NODES = {
         'block_quote',


### PR DESCRIPTION
Allow the user to control the number of suggestions displayed in the
output through a configuration option.

Closes #151