### PR TITLE
ci: do not require django ci job

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,7 +27,7 @@ pull_request_rules:
         - "check-success=build (docs)"
         - "check-success=build (linter)"
         - "check-success=build (spelling)"
-        - "check-success=django"
+        # - "check-success=django"
         - "check-success=build (3.6)"
         - "check-success=build (3.7)"
         - "check-success=build (3.8)"


### PR DESCRIPTION
This can be restored when https://code.djangoproject.com/ticket/33753
is fixed.