### PR TITLE
builder: check text of captions

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -20,6 +20,13 @@ Features
   output. See :doc:`/customize` for more details. Idea contributed by
   Trevor Gross.
 
+Bug Fixes
+---------
+
+- `#36 <https://github.com/sphinx-contrib/spelling/issues/36>`__
+  Include captions of figures in the set of nodes for which the text
+  is checked.
+
 7.4.1
 =====
 

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -168,6 +168,7 @@ class SpellingBuilder(Builder):
 
     TEXT_NODES = {
         'block_quote',
+        'caption',
         'paragraph',
         'list_item',
         'term',

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -257,3 +257,24 @@ def test_get_suggestions_to_show_disabled(sphinx_project):
     stdout, stderr, app = get_sphinx_app(srcdir, outdir, 'contents')
     results = app.builder.get_suggestions_to_show(['a', 'b', 'c'])
     assert len(results) == 0
+
+
+def test_captions(sphinx_project):
+    srcdir, outdir = sphinx_project
+
+    add_file(srcdir, 'contents.rst', '''
+    The Module
+    ==========
+
+    .. figure:: blah.gif
+
+       Teh caption
+
+    ''')
+
+    stdout, stderr, output_text = get_sphinx_output(
+        srcdir,
+        outdir,
+        'contents',
+    )
+    assert '(Teh)' in output_text


### PR DESCRIPTION
Include captions in the list of special text node types the builder
processes.

Fixes #36