### PR TITLE
builder: add tests for multiple wordlist filenames

### DIFF
--- a/docs/source/customize.rst
+++ b/docs/source/customize.rst
@@ -27,10 +27,12 @@ Input Options
   String specifying a file containing a list of words known to be
   spelled correctly but that do not appear in the language dictionary
   selected by ``spelling_lang``.  The file should contain one word per
-  line. Refer to the `PyEnchant tutorial`_ for details. To add multiple
-  files use a list, or a comma separated string. This is useful when
-  calling sphinx with ``-D spelling_word_list_filename=...`` which will
-  not accept a list and will only accept a string parameter.
+  line. Refer to the `PyEnchant tutorial`_ for details.
+
+  To add multiple files use a list, or a comma separated string. This
+  is useful when calling sphinx with ``-D
+  spelling_word_list_filename=...`` which will not accept a list and
+  will only accept a string parameter.
 
 ``spelling_word_list_filename=['spelling_wordlist.txt','another_list.txt']``
 

--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -20,7 +20,6 @@ Features
   Added configuration option to limit the number of suggestions
   output. See :doc:`/customize` for more details. Idea contributed by
   Trevor Gross.
-
 - `#169 <https://github.com/sphinx-contrib/spelling/issues/169>`__
   Adds the ability to pass in multiple wordlists via the sphinx
   command line as ``-D spelling_word_list_filename=file1,file2``.


### PR DESCRIPTION
Add tests for previous work to support multiple wordlist filenames.

Clean up documentation for the configuration option.

Refactor wordlist filename handling in the builder to make it more
testable.

Fixes #169