### PR TITLE
filters: trap exits from imported modules

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -13,6 +13,14 @@
 Next
 ====
 
+Bug Fixes
+---------
+
+- `#180 <https://github.com/sphinx-contrib/spelling/issues/180>`__
+  Suppress `SystemExit` errors in `ImportableModuleFilter` caused by
+  importing modules that run code on import and exit when that code
+  sees an error. Bug report and reproducer provided by Trevor Gross.
+
 Features
 --------
 

--- a/sphinxcontrib/spelling/filters.py
+++ b/sphinxcontrib/spelling/filters.py
@@ -209,8 +209,8 @@ class ImportableModuleFilter(Filter):
             self.sought_modules.add(word)
             try:
                 mod = importlib.util.find_spec(word)
-            except Exception as err:
-                # This could be an ImportError, some more detailed
+            except BaseException as err:
+                # This could be an ImportError, SystemExit, some more detailed
                 # error out of distutils, or something else triggered
                 # by failing to be able to import a parent package to
                 # use the metadata to search for a subpackage.

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,10 @@ envlist=py,linter,docs
 extras =
     test
 commands=
-    pytest \
+    python -m pytest \
       --cov=sphinxcontrib.spelling \
-      --cov-report term-missing
+      --cov-report term-missing \
+      --log-level DEBUG
 passenv=
     # Let the caller point to where libenchant is on their system, in
     # case it's in an unusual place. For example, on macOS with


### PR DESCRIPTION
Fix the ImportableModuleFilter so that when importing a module results in a
SystemExit being raised we trap the exit and treat it as an issue finding
the module.

Fixes #180