### PR TITLE
Fix spelling:word role rendering verbatim

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -9,6 +9,15 @@
    macOS
    unmaintained
 
+Unreleased
+==========
+
+Bug Fixes
+---------
+
+- `#188 <https://github.com/sphinx-contrib/spelling/issues/188>`__
+  Fix `:spelling:word:` directives from being printed verbatim in
+  output files.
 
 7.6.0
 =====

--- a/sphinxcontrib/spelling/domain.py
+++ b/sphinxcontrib/spelling/domain.py
@@ -1,4 +1,3 @@
-from docutils import nodes
 from sphinx.domains import Domain
 
 from . import directive, role
@@ -12,7 +11,7 @@ class SpellingDomain(Domain):
         'word-list': directive.SpellingDirective,
     }
     roles = {
-        'word': role.WordRole('spelling:word', nodes.Text),
+        'word': role.spelling_word,
     }
 
     def get_objects(self):

--- a/sphinxcontrib/spelling/role.py
+++ b/sphinxcontrib/spelling/role.py
@@ -1,17 +1,14 @@
-from docutils.parsers.rst import roles
+from docutils import nodes
 
 from . import directive
 
 
-class WordRole(roles.GenericRole):
-    """Let the user indicate that inline text is spelled correctly.
-    """
-
-    def __call__(self, role, rawtext, text, lineno, inliner,
-                 options={}, content=[]):
-        env = inliner.document.settings.env
-        docname = env.docname
-        good_words = text.split()
-        directive.add_good_words_to_document(env, docname, good_words)
-        return super().__call__(role, rawtext, text, lineno, inliner,
-                                options=options, content=content)
+def spelling_word(role, rawtext, text, lineno, inliner,
+                  options={}, content=[]):
+    """Let the user indicate that inline text is spelled correctly."""
+    env = inliner.document.settings.env
+    docname = env.docname
+    good_words = text.split()
+    directive.add_good_words_to_document(env, docname, good_words)
+    node = nodes.Text(text)
+    return [node], []


### PR DESCRIPTION
A line like:
> This :spelling:word\`foobared\` role needs to be fixed.

would be rendered in the output exactly like that, instead of what it should be:
> This foobared role needs to be fixed.

Turns out the cause is quite simple: the nodes.Text object from docutils does not hold both the raw text and the "real" text, so it is being passed the raw text, which includes the role name as we see it.

Add a test case to cover this as well.

**NOTE**: The other (shorter) way to fix this is simply to change this line:
https://github.com/sphinx-contrib/spelling/blob/f4a419ed6341ba929c0007e82eb1652d9ee60d38/sphinxcontrib/spelling/role.py#L16
to
```python
        return super().__call__(role, text, text, lineno, inliner, 
```
But I think that is more hacky. If you disagree, I can edit this commit.

Fixes #188