### PR TITLE
Update setup.cfg to use description_file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sphinxcontrib-spelling
-description-file = README
+description_file = README
 author = Doug Hellmann
 author_email = doug@doughellmann.com
 summary = Sphinx spelling extension


### PR DESCRIPTION
Fix the following setuptools deprecation warning:

> Usage of dash-separated 'description-file' will not be supported
> in future versions. Please use the underscore name 'description_file'
> instead