### PR TITLE
Add a spelling ignore role

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -22,7 +22,7 @@ New Features
 
 - `#199 <https://github.com/sphinx-contrib/spelling/pull/199>`__
 - Add ``spelling:ignore`` role for marking inline text to not be
-  checked.  Allow single instances of mispelt words to be ignored,
+  checked.  Allow single instances of mispelled words to be ignored,
   but still flag any other instances as misspellings.
 
 7.6.2

--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -22,7 +22,7 @@ New Features
 
 - `#199 <https://github.com/sphinx-contrib/spelling/pull/199>`__
 - Add ``spelling:ignore`` role for marking inline text to not be
-  checked.  Allow single instances of mispelled words to be ignored,
+  checked.  Allow single instances of misspelled words to be ignored,
   but still flag any other instances as misspellings.
 
 7.6.2

--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -9,6 +9,22 @@
    macOS
    unmaintained
 
+Unreleased
+==========
+
+Bug Fixes
+---------
+
+None.
+
+New Features
+------------
+
+- `#199 <https://github.com/sphinx-contrib/spelling/pull/199>`__
+- Add ``spelling:ignore`` role for marking inline text to not be
+  checked.  Allow single instances of mispelt words to be ignored,
+  but still flag any other instances as misspellings.
+
 7.6.2
 =====
 

--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -217,7 +217,8 @@ class SpellingBuilder(Builder):
         for node in doctree.traverse(docutils.nodes.Text):
             if (node.tagname == '#text' and
                     node.parent and
-                    node.parent.tagname in self.TEXT_NODES):
+                    node.parent.tagname in self.TEXT_NODES and
+                    not hasattr(node, "spellingIgnore")):
 
                 # Get the location of the text being checked so we can
                 # report it in the output file. Nodes from text that

--- a/sphinxcontrib/spelling/domain.py
+++ b/sphinxcontrib/spelling/domain.py
@@ -12,6 +12,7 @@ class SpellingDomain(Domain):
     }
     roles = {
         'word': role.spelling_word,
+        'ignore': role.spelling_ignore
     }
 
     def get_objects(self):

--- a/sphinxcontrib/spelling/role.py
+++ b/sphinxcontrib/spelling/role.py
@@ -12,3 +12,10 @@ def spelling_word(role, rawtext, text, lineno, inliner,
     directive.add_good_words_to_document(env, docname, good_words)
     node = nodes.Text(text)
     return [node], []
+
+def spelling_ignore(role, rawtext, text, lineno, inliner,
+                  options={}, content=[]):
+    """Let the user indicate that inline text is to not be spellchecked."""
+    node = nodes.Text(text)
+    setattr(node, "spellingIgnore", True)
+    return [node], []

--- a/sphinxcontrib/spelling/role.py
+++ b/sphinxcontrib/spelling/role.py
@@ -13,6 +13,7 @@ def spelling_word(role, rawtext, text, lineno, inliner,
     node = nodes.Text(text)
     return [node], []
 
+
 def spelling_ignore(role, rawtext, text, lineno, inliner,
                     options={}, content=[]):
     """Let the user indicate that inline text is to not be spellchecked."""

--- a/sphinxcontrib/spelling/role.py
+++ b/sphinxcontrib/spelling/role.py
@@ -14,7 +14,7 @@ def spelling_word(role, rawtext, text, lineno, inliner,
     return [node], []
 
 def spelling_ignore(role, rawtext, text, lineno, inliner,
-                  options={}, content=[]):
+                    options={}, content=[]):
     """Let the user indicate that inline text is to not be spellchecked."""
     node = nodes.Text(text)
     setattr(node, "spellingIgnore", True)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -472,3 +472,72 @@ def test_domain_role_output(sphinx_project):
         output_text = None
 
     assert output_text == "The Module\n**********\n\nteh is OK\n"
+
+def test_domain_ignore(sphinx_project):
+    srcdir, outdir = sphinx_project
+
+    add_file(srcdir, 'contents.rst', '''
+    The Module
+    ==========
+
+    :spelling:ignore:`baddddd` is OK
+
+    ''')
+
+    stdout, stderr, output_text = get_sphinx_output(
+        srcdir,
+        outdir,
+        'contents',
+    )
+    assert output_text is None
+
+
+def test_domain_ignore_multiple_words(sphinx_project):
+    srcdir, outdir = sphinx_project
+
+    add_file(srcdir, 'contents.rst', '''
+    The Module
+    ==========
+
+    :spelling:ignore:`baddddd` is OK here.
+
+    But, baddddd is not OK here.
+    Nor, here baddddd.
+
+    ''')
+
+    stdout, stderr, output_text = get_sphinx_output(
+        srcdir,
+        outdir,
+        'contents',
+    )
+    assert '(baddddd)' in output_text
+    assert output_text.count('\n') == 2 # Only expect 2 errors, not 3.
+
+
+def test_domain_ignore_output(sphinx_project):
+    srcdir, outdir = sphinx_project
+
+    add_file(srcdir, 'contents.rst', '''
+    The Module
+    ==========
+
+    :spelling:ignore:`teh` is OK
+
+    ''')
+
+    stdout, stderr, output_text = get_sphinx_output(
+        srcdir,
+        outdir,
+        'contents',
+        'text',
+    )
+
+    path = os.path.join(outdir, 'contents.txt')
+    try:
+        with open(path, 'r') as f:
+            output_text = f.read()
+    except FileNotFoundError:
+        output_text = None
+
+    assert output_text == "The Module\n**********\n\nteh is OK\n"


### PR DESCRIPTION
This is an attempt to add a `:spelling:ignore:` role that allows a particular word, or phrase, to be ignored by the spelling checker _but only in this location_.

It does not add the word to the list of good words.  Any other occurrences of the word elsewhere _will_ be flagged as spelling errors. (Unless it _is_ actually spelt correctly of course).

This fixes #198.