### PR TITLE
add test showing that only directive works for ignoring blocks

### DIFF
--- a/sphinxcontrib/spelling/builder.py
+++ b/sphinxcontrib/spelling/builder.py
@@ -226,7 +226,7 @@ class SpellingBuilder(Builder):
                 return False
             return True
 
-        for node in doctree.traverse(filter):
+        for node in doctree.findall(filter):
             # Get the location of the text being checked so we can
             # report it in the output file. Nodes from text that
             # comes in via an 'include' directive does not include

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -13,7 +13,7 @@ import pytest
 import sphinx
 from sphinx.application import Sphinx
 
-from tests import helpers # isort:skip
+from tests import helpers  # isort:skip
 
 
 def _make_sphinx_project(tmpdir):
@@ -446,6 +446,7 @@ def test_domain_role_multiple_words(sphinx_project):
     )
     assert output_text is None
 
+
 def test_domain_role_output(sphinx_project):
     srcdir, outdir = sphinx_project
 
@@ -472,6 +473,7 @@ def test_domain_role_output(sphinx_project):
         output_text = None
 
     assert output_text == "The Module\n**********\n\nteh is OK\n"
+
 
 def test_domain_ignore(sphinx_project):
     srcdir, outdir = sphinx_project
@@ -512,7 +514,7 @@ def test_domain_ignore_multiple_words(sphinx_project):
         'contents',
     )
     assert '(baddddd)' in output_text
-    assert output_text.count('\n') == 2 # Only expect 2 errors, not 3.
+    assert output_text.count('\n') == 2  # Only expect 2 errors, not 3.
 
 
 def test_domain_ignore_output(sphinx_project):

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -543,3 +543,28 @@ def test_domain_ignore_output(sphinx_project):
         output_text = None
 
     assert output_text == "The Module\n**********\n\nteh is OK\n"
+
+
+def test_only_directive(sphinx_project):
+    # How to skip checking nested blocks of content
+    # https://github.com/sphinx-contrib/spelling/issues/204
+    srcdir, outdir = sphinx_project
+
+    add_file(srcdir, 'contents.rst', '''
+    The Module
+    ==========
+
+    .. only:: html
+
+       teh is ok
+
+    whaat is not ok
+    ''')
+
+    stdout, stderr, output_text = get_sphinx_output(
+        srcdir,
+        outdir,
+        'contents',
+    )
+    assert '(whaat)' in output_text
+    assert '(teh)' not in output_text


### PR DESCRIPTION
Add a test showing that the `only` directive works for ignoring sections of
content that has content that should not be checked.

Addresses #204