### PR TITLE
Clean up allocated TLS socket @ PyPI filter

### DIFF
--- a/sphinxcontrib/spelling/filters.py
+++ b/sphinxcontrib/spelling/filters.py
@@ -162,8 +162,8 @@ class PyPIFilterFactory(IgnoreWordsFilterFactory):
     """Build an IgnoreWordsFilter for all of the names of packages on PyPI.
     """
     def __init__(self):
-        client = xmlrpc_client.ServerProxy('https://pypi.python.org/pypi')
-        super().__init__(client.list_packages())
+        with xmlrpc_client.ServerProxy('https://pypi.python.org/pypi') as client:
+            super().__init__(client.list_packages())
 
 
 class PythonBuiltinsFilter(Filter):


### PR DESCRIPTION
Invoking `python -Werror -m sphinx -b spelling ...` surfaces a resource warning related to not releasing the TLS socket that `xmlrpc.client.ServerProxy()` opens. There's no explicit mention of a cleanup method in the stdlib docs but there's one example with a context manager. I inspected the source code and it seems like we should either use a CM or a rather weird callable interface (`xmlrpc.client.ServerProxy()('close')()`). I opted for a CM.

```python-traceback
[...]
Ignoring wiki words
Ignoring acronyms
Adding package names from PyPI to local dictionary…
Exception ignored in: <ssl.SSLSocket fd=3, family=2, type=1, proto=6, laddr=('192.168.1.114', 53560), raddr=('146.75.120.223', 443)>
Traceback (most recent call last):
  File "~/src/github/a/project/.tox/build-docs/lib/python3.12/site-packages/sphinxcontrib/spelling/builder.py", line 65, in init
    f.append(filters.PyPIFilterFactory())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
ResourceWarning: unclosed <ssl.SSLSocket fd=3, family=2, type=1, proto=6, laddr=('192.168.1.114', 53560), raddr=('146.75.120.223', 443)>
Ignoring Python builtins
Ignoring importable module names
Ignoring contributor names
[...]
```

## Disclaimer

This patch is coded in-browser on the GH UI w/ no testing. It might need some love and/or tests.