### PR TITLE
gracefully handle if git is not installed

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -30,6 +30,12 @@ Next
 - Modernize packaging using setuptools, build, and setuptools_scm
   instead of pbr.
 
+Bug Fixes
+---------
+
+- `#229 <https://github.com/sphinx-contrib/spelling/pull/229>`__ Gracefully
+  handle if git is not installed
+
 7.7.0
 =====
 

--- a/sphinxcontrib/spelling/filters.py
+++ b/sphinxcontrib/spelling/filters.py
@@ -245,7 +245,7 @@ class ContributorFilter(IgnoreWordsFilter):
 
         try:
             p = subprocess.run(cmd, check=True, stdout=subprocess.PIPE)
-        except subprocess.CalledProcessError as err:
+        except (subprocess.CalledProcessError, FileNotFoundError) as err:
             logger.warning('Called: %s', ' '.join(cmd))
             logger.warning('Failed to scan contributors: %s', err)
             return set()


### PR DESCRIPTION
The following error occurs in `_get_contributors()` if git is not installed.

> FileNotFoundError: [Errno 2] No such file or directory: 'git': 'git'

Treat this the same as if `git` fails, catch the error and print a warning.